### PR TITLE
Never leave xp_id empty

### DIFF
--- a/cryohub/utils/generic.py
+++ b/cryohub/utils/generic.py
@@ -14,9 +14,10 @@ class ParseError(RuntimeError):
 
 # a list of commonly used base names for paths in regex form
 common_name_regexes = (
-    r"^\w+\d+",
-    r"^\w+_\d+",
-    r"\d+",
+    r"^(\w+\d+).*\.",
+    r"^(\w+_\d+).*\.",
+    r"^(.*\d+).*\.",
+    r"^(.*?)\.",
 )
 
 
@@ -26,7 +27,7 @@ def guess_name(string, name_regex=None):
     and a list of regexes in order of priority
     """
     if string is None:
-        return ""
+        return "NO_ID"
     string = Path(string).stem
     name_regex = listify(name_regex)
     regexes = list(common_name_regexes)
@@ -37,7 +38,7 @@ def guess_name(string, name_regex=None):
                 return match.group(1)
             return match.group(0)
     else:
-        return ""
+        return "NO_ID"
 
 
 def pad_to_3D(arr):


### PR DESCRIPTION
Some issues arise (especially when saving star files) when exp_id is empty. Ensure we always have a fallback value for such cases.

I also improved the guessing a bit so it covers more cases and fails less.